### PR TITLE
Remove requirement for Moose::Autobox in tests

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension {{$dist->name}}
 
 {{$NEXT}}
+  - Remove requirement for Moose::Autobox in tests [kentnl, GH #6]
 
 2.000006  2014-04-29
   - Allow specifying a list of files to test manually

--- a/t/deprecated.t
+++ b/t/deprecated.t
@@ -4,7 +4,6 @@ use Test::More 0.96 tests => 2;
 use Test::Output;
 use autodie;
 use Test::DZil;
-use Moose::Autobox;
 
 my $tzil;
 
@@ -24,7 +23,7 @@ stderr_like(
 
 $tzil->build;
 
-my @xtests = map $_->name =~ m{^xt/} ? $_->name : (), $tzil->files->flatten;
+my @xtests = map $_->name =~ m{^xt/} ? $_->name : (), @{ $tzil->files };
 ok(
     (grep { $_ eq 'xt/release/unused-vars.t' } @xtests),
     'unused-vars.t exists'

--- a/t/file-list.t
+++ b/t/file-list.t
@@ -3,7 +3,7 @@ use warnings;
 use Test::More 0.96 tests => 3;
 use autodie;
 use Test::DZil;
-use Moose::Autobox;
+use List::Util qw( first );
 use Path::Tiny;
 
 subtest 'file list' => sub {
@@ -21,7 +21,7 @@ subtest 'file list' => sub {
     });
     $tzil->build;
 
-    my ($test) = grep { $_->name eq 'xt/release/unused-vars.t' } $tzil->files->flatten;
+    my ($test) = first { $_->name eq 'xt/release/unused-vars.t' } @{ $tzil->files };
     like $test->content => qr{\Q$_} for @files_to_test;
 };
 
@@ -43,7 +43,7 @@ subtest 'naughty filenames' => sub {
     });
     $tzil->build;
 
-    my ($test) = grep { $_->name eq 'xt/release/unused-vars.t' } $tzil->files->flatten;
+    my ($test) = first { $_->name eq 'xt/release/unused-vars.t' } @{ $tzil->files };
 
     run3([$^X => '-c'], \$test->content, \my $stdout, \my $stderr);
     isnt index($stderr => q/syntax OK/), -1
@@ -62,6 +62,6 @@ subtest 'all files' => sub {
     });
     $tzil->build;
 
-    my ($test) = grep { $_->name eq 'xt/release/unused-vars.t' } $tzil->files->flatten;
+    my ($test) = first { $_->name eq 'xt/release/unused-vars.t' } @{ $tzil->files };
     like $test->content => qr{\Qall_vars_ok};
 };

--- a/t/test-created.t
+++ b/t/test-created.t
@@ -3,7 +3,6 @@ use warnings;
 use Test::More 0.96 tests => 1;
 use autodie;
 use Test::DZil;
-use Moose::Autobox;
 
 my $tzil = Builder->from_config(
     { dist_root => 'corpus/DZ1' },
@@ -17,7 +16,7 @@ my $tzil = Builder->from_config(
 );
 $tzil->build;
 
-my @xtests = map $_->name =~ m{^xt/} ? $_->name : (), $tzil->files->flatten;
+my @xtests = map $_->name =~ m{^xt/} ? $_->name : (), @{ $tzil->files };
 ok(
     (grep { $_ eq 'xt/release/unused-vars.t' } @xtests),
     'unused-vars.t exists'


### PR DESCRIPTION
Yet another. https://github.com/doherty/Dist-Zilla-Plugin-Test-CPAN-Changes/pull/5 