### PR TITLE
Allow specifying variables to ignore

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Perl extension {{$dist->name}}
 
 {{$NEXT}}
 
+  - Allow specifying variables to ignore.
+
 2.000007  2015-01-22
   - Remove requirement for Moose::Autobox in tests [kentnl, GH #6]
 

--- a/corpus/DZ1/MANIFEST
+++ b/corpus/DZ1/MANIFEST
@@ -1,0 +1,3 @@
+lib/DZ1.pm
+lib/DZ1/file1.pm
+lib/DZ1/file2.pm

--- a/corpus/DZ1/lib/DZ1/file1.pm
+++ b/corpus/DZ1/lib/DZ1/file1.pm
@@ -1,0 +1,11 @@
+package DZ1::file1;
+
+sub main {
+    my $var1;
+    my @var2;
+    my %var3;
+
+    1;
+}
+
+1;

--- a/corpus/DZ1/lib/DZ1/file2.pm
+++ b/corpus/DZ1/lib/DZ1/file2.pm
@@ -1,0 +1,11 @@
+package DZ1::file2;
+
+sub main {
+    my $var1;
+    my @var2;
+    my %var3;
+
+    1;
+}
+
+1;

--- a/lib/Dist/Zilla/Plugin/Test/UnusedVars.pm
+++ b/lib/Dist/Zilla/Plugin/Test/UnusedVars.pm
@@ -19,16 +19,46 @@ has files => (
     predicate => 'has_files',
 );
 
+has ignore_vars => (
+    is  => 'ro',
+    isa => 'Maybe[ArrayRef[Str]]',
+    predicate => 'has_ignore_vars',
+);
+
 =for Pod::Coverage *EVERYTHING*
 
 =cut
 
-sub mvp_multivalue_args { return qw/ files / }
-sub mvp_aliases { return { file => 'files' } }
+sub mvp_multivalue_args { return qw/ files ignore_vars / }
+sub mvp_aliases { return { file => 'files', ignore_var => 'ignore_vars' } }
+
+sub _normalize_path {
+    path($_[0])->relative('lib')->stringify;
+}
 
 sub gather_files {
     my $self = shift;
     my $file = 'xt/release/unused-vars.t';
+
+    my @files;
+    @files = map { _normalize_path( $_) } @{ $self->files }
+      if $self->has_files;
+
+    # accomodate file specific ignored vars
+    my %ignore_vars;
+    if ( $self->has_ignore_vars ) {
+        for my $var_spec ( @{ $self->ignore_vars } ) {
+            my ( $file, $var ) = $var_spec =~ /^(?:(.*):)?(.*)$/;
+            my $key = defined $file ? _normalize_path( $file ) : '';
+            push @{ $ignore_vars{$key} ||= [] }, $var;
+        }
+    }
+
+    # add globally ignored files to each file's list.
+    if ( defined $ignore_vars{''} ) {
+        push @{ $ignore_vars{$_} ||= [] }, @{ $ignore_vars{''} }
+          for @files;
+    }
 
     require Dist::Zilla::File::InMemory;
     $self->add_file(
@@ -38,11 +68,10 @@ sub gather_files {
                 ${ $self->section_data($file) },
                 {
                     has_files => $self->has_files,
-                    files => ($self->has_files
-                        ? [ map { path($_)->relative('lib')->stringify } @{ $self->files } ]
-                        : []
-                    ),
-                }
+                    files => \@files,
+                    has_ignore_vars => $self->has_ignore_vars,
+                    ignore_vars => \%ignore_vars,
+                },
             ),
         })
     );
@@ -63,6 +92,29 @@ Or, give a list of files to test:
     [Test::UnusedVars]
     file = lib/My/Module.pm
     file = bin/verify-this
+
+Ignore some variables:
+
+    [Test::UnusedVars]
+    ignore_var = $guard
+    ignore_var = $raii
+
+Ignore variables in a particular file:
+
+    [Test::UnusedVars]
+    ; ignore $guard in all files
+    ignore_var = $guard
+    ; ignore $foo only in lib/My/Module.pm
+    ignore_var = lib/My/Module.pm:$foo
+
+    ; unfortunately, must list all files
+    file = lib/My/Module.pm
+    file = bin/verify-this
+
+A file specific variable is only ignored if the file is specified in a C<file> option.
+Unfortunately, because of the current implementation, this means that I<all> files must
+be specified via C<file> options.
+
 
 =for test_synopsis
 1;
@@ -91,12 +143,32 @@ SKIP: {
 
     subtest 'unused vars' => sub {
 {{
-$has_files
-    ? 'my @files = (' . "\n"
-        . join(",\n", map { q{    '} . $_ . q{'} } map { s{'}{\\'}g; $_ } @files)
-        . "\n" . ');' . "\n"
-        . 'vars_ok($_) for @files;'
-    : 'all_vars_ok();'
+    my $qwote_vars = sub { join ' ', 'qw[', @{ $ignore_vars{$_[0]} }, ']' };
+    my $indent = "    " x 2;
+
+    if ( $has_files ) {
+        for my $file ( @files ) {
+            $OUT .= "\n" if length $OUT;
+            $OUT .= $indent;
+            (my $qfile = $file ) =~ s{'}{\\'}g;;
+            if ( $ignore_vars{$file} ) {
+                $OUT .= "vars_ok('$qfile', ignore_vars => [ @{[ $qwote_vars->($file) ]} ] );";
+            }
+            else {
+                $OUT .= "vars_ok('$qfile');"
+            }
+        }
+    }
+
+    else {
+        $OUT .= $indent;
+        if ( $has_ignore_vars && defined $ignore_vars{''} ) {
+            $OUT .= "all_vars_ok( ignore_vars => [ @{[ $qwote_vars->('') ]} ] );"
+        }
+        else {
+            $OUT .= "all_vars_ok();"
+        }
+    }
 }}
     };
 };

--- a/t/ignore_vars.t
+++ b/t/ignore_vars.t
@@ -1,0 +1,252 @@
+use strict;
+use warnings;
+use Test::More 0.96 tests => 3;
+use autodie;
+use Test::DZil;
+use List::Util qw( first );
+use Path::Tiny;
+use File::pushd;
+
+my $has_IPC_RUN3 = eval "use IPC::Run3; 1;";
+
+# all of the unused variables that are in the files.
+use constant VARS => qw( $var1 @var2 %var3 );
+
+# files, both as we (this file) see them and as is in the normalized form in the test code
+use constant FILES     => qw( lib/DZ1/file1.pm lib/DZ1/file2.pm );
+use constant normFILES => qw(     DZ1/file1.pm     DZ1/file2.pm );
+
+# a subset of the unused variables that will be ignored
+use constant IgnoredFileVARS =>
+  qw( lib/DZ1/file1.pm:$var1
+      lib/DZ1/file2.pm:@var2
+      lib/DZ1/file2.pm:%var3
+);
+
+# all of the unused variables if there are no ignores, in "$file:$var" form
+use constant NoIgnores => sort
+                    map {
+                        my $var = $_;
+                        map {
+                            "$_:$var"
+                        } FILES
+                    } VARS;
+
+sub gen_code {
+
+    my $tzil = Builder->from_config(
+        { dist_root => 'corpus/DZ1' },
+        {
+            add_files => {
+                'source/dist.ini' =>
+                  simple_ini( 'GatherDir', ['Test::UnusedVars', { @_ } ], ),
+            },
+        } );
+
+    my $guard = pushd 'corpus/DZ1';
+    $tzil->build;
+
+    my ( $test ) = first { $_->name eq 'xt/release/unused-vars.t' } @{ $tzil->files };
+
+    return $test->content;
+}
+
+sub run_code {
+    my  ($code, $stdout, $stderr) = @_;
+    my $guard = pushd 'corpus/DZ1';
+    run3( [$^X => '-Ilib' ], $code, $stdout, $stderr );
+}
+
+# extract the "used once" errors from a test run so that we can test for completeness.
+sub grep_output {
+    my $output = shift;
+
+    [ sort map {
+        m{(\S+)\s* is used once .* at (lib/.*\.pm)};
+        "$2:$1"
+            } grep { /is used once/ } split(/\n/, $output )
+   ]
+}
+
+sub subtestx { }
+
+# make sure the tests actually work
+subtest 'base' => sub {
+
+    subtest 'all files' => sub {
+
+        plan skip_all => "requires IPC::Run3 to test"
+          unless $has_IPC_RUN3;
+
+        my $code = gen_code();
+
+        run_code( \$code, \my $stdout, \my $stderr );
+        isnt( $?, 0, "run test on code" )
+          or diag "expected errors, got none?";
+
+        is_deeply( grep_output( $stderr ), [ NoIgnores ], "unused vars" );
+    };
+
+    subtest 'files' => sub {
+
+        plan skip_all => "requires IPC::Run3 to test"
+          unless $has_IPC_RUN3;
+
+        plan tests => 2;
+
+        my $code = gen_code( files => [ FILES ] );
+
+        run_code( \$code, \my $stdout, \my $stderr );
+        isnt( $?, 0, "run test on code" )
+          or diag "expected errors, got none?";
+
+        is_deeply( grep_output( $stderr ), [ NoIgnores ] , "unused vars" );
+    };
+};
+
+subtest 'global ignore vars' => sub {
+    plan tests => 2;
+
+    subtest 'all files' => sub {
+        plan tests => 2;
+
+        my @vars = VARS;
+        my $code = gen_code( ignore_vars => \@vars );
+
+        subtest "generated test" => sub {
+            plan tests => 2 + @vars;
+
+            unlike $code => qr{\svars_ok}, "shouldn't have individual file tests";
+            like   $code => qr{all_vars_ok}, "should have all file tests";
+            like   $code => qr{\Q$_}, "ignore $_" for @vars;
+        };
+
+        subtest "run test" => sub {
+            plan skip_all => "requires IPC::Run3 to test", 1
+              unless $has_IPC_RUN3;
+
+            plan tests => 1;
+
+            run_code( \$code, \my $stdout, \my $stderr );
+            is( $?, 0, "run test on code" )
+              or do {
+                diag "Test Code:\n", $code;
+                diag "STDERR:\n$stderr";
+                diag "STDOUT:\n$stdout";
+              };
+        };
+    };
+
+
+    subtest 'files' => sub {
+        plan tests => 2;
+
+        my @vars  = VARS;
+        my @files = FILES;
+        my @norm_files = normFILES;
+
+        my $code = gen_code( files => \@files, ignore_vars => \@vars );
+
+        subtest "generated test" => sub {
+            plan tests => 1 + @vars * @files;
+
+            unlike $code => qr{all_vars_ok}, "shouldn't have all file tests";
+
+            for my $file ( @norm_files ) {
+                like $code => qr{\svars_ok.*'$file'\s?,.*\Q$_}, "$file, $_"
+                  for @vars;
+            }
+        };
+
+        subtest "run test" => sub {
+            plan skip_all => "requires IPC::Run3 to test", 1
+              unless $has_IPC_RUN3;
+
+            plan tests => 1;
+
+            run_code( \$code, \my $stdout, \my $stderr );
+            is( $?, 0, "run test on code" )
+              or do {
+                diag "Test Code:\n", $code;
+                diag "STDERR:\n$stderr";
+                diag "STDOUT:\n$stdout";
+              };
+        };
+    };
+};
+
+
+subtest 'per-file ignore vars' => sub {
+    plan tests => 2;
+
+    subtest 'all files' => sub {
+        plan tests => 2;
+
+        my @vars = VARS;
+        my $code = gen_code( ignore_vars => [IgnoredFileVARS] );
+
+        subtest "generated test" => sub {
+            plan tests => 2 + @vars;
+
+            unlike $code => qr{\svars_ok}, "shouldn't have individual file tests";
+            like $code => qr{all_vars_ok}, "should have all file tests";
+            unlike $code => qr{\Q$_}, "shouldn't ignore $_" for @vars;
+        };
+
+        subtest "run test" => sub {
+            plan skip_all => "requires IPC::Run3 to test", 1
+              unless $has_IPC_RUN3;
+
+            plan tests => 1 + @vars;
+
+            run_code( \$code, \my $stdout, \my $stderr );
+            isnt( $?, 0, "run test on code" )
+              or diag "expected errors, got none?";
+
+             note $stderr;
+
+            like $stderr, qr{\Q$_ is used once}, "$_ is used once" for @vars;
+        };
+    };
+
+    subtest 'files' => sub {
+        plan tests => 2;
+
+        my @vars  = VARS;
+        my @files = FILES;
+        my $code = gen_code( files => \@files, ignore_vars => [ IgnoredFileVARS ] );
+
+        subtest "generated test" => sub {
+            plan tests => 3;
+
+            unlike $code => qr{all_vars_ok}, "shouldn't have all file tests";
+            like   $code => qr{\svars_ok.*'DZ1/file1\.pm'\s?,.*\$var1}, 'file1, $var1';
+            like   $code => qr{\svars_ok.*'DZ1/file2\.pm'\s?,.*\@var2\s+%var3}, 'file2, @var2, %var3';
+        };
+
+        subtest "run test" => sub {
+            plan skip_all => "requires IPC::Run3 to test", 1
+              unless $has_IPC_RUN3;
+
+            plan tests => 2;
+
+            run_code( \$code, \my $stdout, \my $stderr );
+            isnt( $?, 0, "run test on code" )
+              or do {
+                diag "Test Code:\n", $code;
+                diag "STDERR:\n$stderr";
+                diag "STDOUT:\n$stdout";
+              };
+
+            is_deeply( grep_output( $stderr ),
+                       [
+                        sort
+                        qw( lib/DZ1/file2.pm:$var1
+                            lib/DZ1/file1.pm:@var2
+                            lib/DZ1/file1.pm:%var3
+                         )
+                       ],
+                       "unused vars" );
+        };
+    };
+};


### PR DESCRIPTION
This provides access to Test::Var's ignore_var functionality, including specifying per-file ignorable variables.
